### PR TITLE
Added ignore case functionality and catered for more Xpath expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Contributors
 
 * blumf
 * Ivan Baidakou (basiliscos)
+* Rohan de Jongh (thepeanutgalleryandco)

--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -65,8 +65,8 @@
 
           <h2><a name="status"></a>Status</h2>
 
-          <p>Current version is 1.2. It was developed for Lua 5.1 based on <a href="http://www.keplerproject.org/luaexpat">
-            LuaExpat</a> but also should work with Lua 5.2 and 5.3.
+          <p>Current version is 1.3. It was developed for Lua 5.1 based on <a href="http://www.keplerproject.org/luaexpat">
+            LuaExpat</a> but also should work with Lua 5.2, 5.3 and 5.4.
           </p>
 
 
@@ -78,6 +78,13 @@
 
           <h2><a name="history"></a>History</h2>
           <dl class="history">
+	    <dt><strong>Version 1.3</strong> [10/July/2024]</dt>
+	    <dd><ul>
+              <li>Added ignore case functionality</li>
+              <li>Added support for more XPath expressions that might be more complex</li>
+              <li>Added comments in library</li>
+	    </ul></dd>
+
 	    <dt><strong>Version 1.2</strong> [15/Mar/2015]</dt>
 	    <dd><ul>
               <li>Moved to github and a bit reogranized project structure</li>

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -126,9 +126,12 @@ xpath.selectNodes(lom.parse(xmlTest),'/root/element/node()')
 -- get all child nodes of root
 xpath.selectNodes(lom.parse(xmlTest),'/root/*')
 
--- not done
--- get all child nodes of root that contains a name of element
--- xpath.selectNodes(lom.parse(xmlTest),'/root[contains(name, "element")]')
+-- get all child nodes of root that contains an attribute of name which is equal to element
+xpath.selectNodes(lom.parse(xmlTest),'/root/element[contains(@name, "element")]')
+
+-- get all element nodes that contains an attribute of name which starts with ele
+xpath.selectNodes(lom.parse(xmlTest),'/root/element[starts-with(@name, "ele")]')
+
 
 </pre>
 

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -85,27 +85,27 @@ local lom = require "lxp.lom"
 local xmlTest =
 [[
 &lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
-&lt;root&gt;
+&lt;root xmlns:test="https://test.test/"&gt;
   &lt;element id="1" name="element1"&gt;text of the first element&lt;/element&gt;
   &lt;element id="2" name="element2"&gt;
     &lt;subelement&gt;text of the second element&lt;/subelement&gt;
   &lt;/element&gt;
-  &lt;test:newElement id="1" name="newElement"&gt;text of the new element
+  &lt;test:newElement id="1" name="newElement"&gt;
     &lt;test&gt;text of the test element&lt;/test&gt;
-  &lt;/test:newElement&gt;  
+  &lt;/test:newElement&gt;
 &lt;/root&gt;
 ]]
 
--- get all element nodes
+-- get all elements
 xpath.selectNodes(lom.parse(xmlTest),'//element')
 
--- get the subelement node's text
+-- get the subelement text
 xpath.selectNodes(lom.parse(xmlTest),'/root/element/subelement/text()')
 
--- get the element with an attribute of "id" that has the value of "1"
+-- get the element by attribute id 1
 xpath.selectNodes(lom.parse(xmlTest),'/root/element[@id="1"]')
 
--- get the 2nd element node
+-- get node two by index
 xpath.selectNodes(lom.parse(xmlTest),'/root/element[2]')
 
 -- get the first element node, with ignoring the case of element
@@ -116,6 +116,19 @@ xpath.selectNodes(lom.parse(xmlTest),'/root/test:newElement')
 
 -- get the node that has a child node that contains a tag name of subelement
 xpath.selectNodes(lom.parse(xmlTest),'//element[name="subelement"]')
+
+-- get any node that has an attribute of test
+xpath.selectNodes(lom.parse(xmlTest),'//*/@test')
+
+-- get the node by name
+xpath.selectNodes(lom.parse(xmlTest),'/root/element/node()')
+
+-- get all child nodes of root
+xpath.selectNodes(lom.parse(xmlTest),'/root/*')
+
+-- not done
+-- get all child nodes of root that contains a name of element
+-- xpath.selectNodes(lom.parse(xmlTest),'/root[contains(name, "element")]')
 
 </pre>
 

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -73,7 +73,7 @@
   require "luaxpath"
   local lom = require "lxp.lom"
 
-  xpath.selectNodes(lom.parse(xmlString),xpathExpression)
+  xpath.selectNodes(lom.parse(xmlString),xpathExpression,ignoreCase)
 </pre>
 
 <h2><a name="examples"></a>Examples</h2>        
@@ -86,19 +86,37 @@ local xmlTest =
 [[
 &lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
 &lt;root&gt;
-	&lt;element id="1" name="element1"&gt;text of the first element&lt;/element&gt;
-        &lt;element id="2" name="element2"&gt;
-		&lt;subelement&gt;text of the second element&lt;/subelement&gt;
-        &lt;/element&gt;
+  &lt;element id="1" name="element1"&gt;text of the first element&lt;/element&gt;
+  &lt;element id="2" name="element2"&gt;
+    &lt;subelement&gt;text of the second element&lt;/subelement&gt;
+  &lt;/element&gt;
+  &lt;test:newElement id="1" name="newElement"&gt;text of the new element
+    &lt;test&gt;text of the test element&lt;/test&gt;
+  &lt;/test:newElement&gt;  
 &lt;/root&gt;
 ]]
 
--- get all elements
+-- get all element nodes
 xpath.selectNodes(lom.parse(xmlTest),'//element')
--- get the subelement text
+
+-- get the subelement node's text
 xpath.selectNodes(lom.parse(xmlTest),'/root/element/subelement/text()')
--- get the first element
+
+-- get the element with an attribute of "id" that has the value of "1"
 xpath.selectNodes(lom.parse(xmlTest),'/root/element[@id="1"]')
+
+-- get the 2nd element node
+xpath.selectNodes(lom.parse(xmlTest),'/root/element[2]')
+
+-- get the first element node, with ignoring the case of element
+xpath.selectNodes(lom.parse(xmlTest),'/root/ELEMENT[1]',true)
+
+-- get the newElement node and make use of the namespace in the tag name
+xpath.selectNodes(lom.parse(xmlTest),'/root/test:newElement')
+
+-- get the node that has a child node that contains a tag name of subelement
+xpath.selectNodes(lom.parse(xmlTest),'//element[name="subelement"]')
+
 </pre>
 
 <h2><a name="related_docs"></a>Related documentation</h2>        

--- a/rockspecs/luaxpath-1.3-0.rockspec
+++ b/rockspecs/luaxpath-1.3-0.rockspec
@@ -1,8 +1,8 @@
 package = "luaxpath"
-version = "1.2-4"
+version = "1.3-0"
 source = {
    url = "git://github.com/basiliscos/lua-xpath",
-   tag = "v1.2.4",
+   tag = "v1.3.0",
 }
 description = {
    summary = "Simple XPath implementation in the Lua programming language.",

--- a/src/luaxpath/init.lua
+++ b/src/luaxpath/init.lua
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------
 -- Version: 1.3.0
 -- Author: Rohan de Jongh (roebou / thepeanutgalleryandco) + ChatGPT (4.0)
--- Date: 2024-07-11
+-- Date: 2024-07-12
 -----------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------
@@ -101,15 +101,15 @@ local function eval_predicate(value, predicate, ignoreCase)
     end
 
     -- Check for functions like contains() and starts-with()
-    local func, param = predicate:match("([%w]+)%(([%w@]+)%)")
+    local func, param, pattern = predicate:match("([%w-]+)%((@[%w:]+),%s*['\"]([^'\"]+)['\"]%)")
     if func == "contains" then
         local attr2 = param:match("@([%w:]+)")
         if attr2 then
             local v = value.attr and value.attr[attr2]
             if ignoreCase then
-                return v and v:lower():find(val:lower()) ~= nil
+                return v and v:lower():find(pattern:lower()) ~= nil
             else
-                return v and v:find(val) ~= nil
+                return v and v:find(pattern) ~= nil
             end
         end
     elseif func == "starts-with" then
@@ -117,9 +117,9 @@ local function eval_predicate(value, predicate, ignoreCase)
         if attr3 then
             local v = value.attr and value.attr[attr3]
             if ignoreCase then
-                return v and v:lower():sub(1, #val) == val:lower()
+                return v and v:lower():sub(1, #pattern) == pattern:lower()
             else
-                return v and v:sub(1, #val) == val
+                return v and v:sub(1, #pattern) == pattern
             end
         end
     end

--- a/src/luaxpath/init.lua
+++ b/src/luaxpath/init.lua
@@ -13,6 +13,10 @@
 -- Author: blumf
 -- Date: 2015-02-20
 -----------------------------------------------------------------------------
+-- Version: 1.3.0
+-- Author: Rohan de Jongh (roebou / thepeanutgalleryandco) + ChatGPT (4.0)
+-- Date: 2024-07-11
+-----------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------
 -- Declare module and import dependencies
@@ -21,159 +25,261 @@
 local XPath = {}
 XPath.__index = XPath
 
-function XPath._new(option)
-	local o = { _result_table = {}, _option = option }
-	setmetatable(o, XPath)
-	return o
+--- Creates a new XPath object.
+-- @param option The option for selecting nodes (e.g., text(), node()).
+-- @param ignoreCase Boolean to ignore case in tag matching.
+-- @return A new XPath object.
+function XPath._new(option, ignoreCase)
+    local o = { _result_table = {}, _option = option, _ignoreCase = ignoreCase }
+    setmetatable(o, XPath)
+    return o
 end
 
+--- Splits a string by a given pattern.
+-- @param str The string to split.
+-- @param pat The pattern to split by.
+-- @return A table containing the split parts.
 local function _split(str, pat)
-	local t = {}  -- NOTE: use {n = 0} in Lua-5.0
-	local fpat = "(.-)" .. pat
-	local last_end = 1
-	local s, e, cap = str:find(fpat, 1)
-	while s do
-		if s ~= 1 or cap ~= "" then
-			table.insert(t,cap)
-		end
-		last_end = e+1
-		s, e, cap = str:find(fpat, last_end)
-	end
-	if last_end <= #str then
-		cap = str:sub(last_end)
-		table.insert(t, cap)
-	end
-	return t
+    local t = {}
+    local fpat = "(.-)" .. pat
+    local last_end = 1
+    local s, e, cap = str:find(fpat, 1)
+    while s do
+        if s ~= 1 or cap ~= "" then
+            table.insert(t, cap)
+        end
+        last_end = e + 1
+        s, e, cap = str:find(fpat, last_end)
+    end
+    if last_end <= #str then
+        cap = str:sub(last_end)
+        table.insert(t, cap)
+    end
+    return t
 end
-
-
--- local resultTable,option = {},nil
 
 -----------------------------------------------------------------------------
 -- Supported functions
 -----------------------------------------------------------------------------
 
+--- Evaluates a predicate against a value.
+-- @param value The value to evaluate.
+-- @param predicate The predicate to evaluate.
+-- @param ignoreCase Boolean to ignore case in tag matching.
+-- @return The result of the predicate evaluation.
+local function eval_predicate(value, predicate, ignoreCase)
+    -- Check if the predicate is a numeric index
+    if predicate:match("^%d+$") then
+        return tonumber(predicate)
+    end
+
+    -- Check for attribute equality, e.g., @attr='value'
+    local attr, val = predicate:match("@([%w:]+)=['\"]([^'\"]+)['\"]")
+    if attr and val then
+        local v = value.attr and value.attr[attr]
+        if ignoreCase then
+            return v and v:lower() == val:lower()
+        else
+            return v == val
+        end
+    end
+
+    -- Check for element equality, e.g., element='value'
+    local element
+    element, val = predicate:match("([%w:]+)=['\"]([^'\"]+)['\"]")
+    if element and val then
+        for _, subValue in ipairs(value) do
+            if type(subValue) == "table" and subValue.tag == element then
+                local v = subValue[1]
+                if ignoreCase then
+                    return v and v:lower() == val:lower()
+                else
+                    return v == val
+                end
+            end
+        end
+    end
+
+    -- Check for functions like contains() and starts-with()
+    local func, param = predicate:match("([%w]+)%(([%w@]+)%)")
+    if func == "contains" then
+        local attr2 = param:match("@([%w:]+)")
+        if attr2 then
+            local v = value.attr and value.attr[attr2]
+            if ignoreCase then
+                return v and v:lower():find(val:lower()) ~= nil
+            else
+                return v and v:find(val) ~= nil
+            end
+        end
+    elseif func == "starts-with" then
+        local attr3 = param:match("@([%w:]+)")
+        if attr3 then
+            local v = value.attr and value.attr[attr3]
+            if ignoreCase then
+                return v and v:lower():sub(1, #val) == val:lower()
+            else
+                return v and v:sub(1, #val) == val
+            end
+        end
+    end
+
+    return false
+end
+
+--- Matches a tag against an expression.
+-- @param tag The tag to match.
+-- @param tagExpr The expression to match against.
+-- @param value The value to match.
+-- @param ignoreCase Boolean to ignore case in tag matching.
+-- @return True if the tag matches the expression, otherwise false.
+local function match(tag, tagExpr, value, ignoreCase)
+    local expression, evalTag
+
+    -- Match any tag
+    if tagExpr == "*" then
+        return true
+    end
+
+    -- Match root tag
+    if tagExpr == "" then
+        return true
+    end
+
+    -- Match by numeric index, e.g., tag[1]
+    local numericIndex = tonumber(tagExpr:match("%[(%d+)%]"))
+    if numericIndex then
+        return true, numericIndex
+    end
+
+    -- Match predicates, e.g., tag[@attr='value']
+    if tagExpr:find("%[") ~= nil and tagExpr:find("%]") ~= nil then
+        evalTag = tagExpr:sub(1, tagExpr:find("%[") - 1)
+        expression = tagExpr:sub(tagExpr:find("%[") + 1, tagExpr:find("%]") - 1)
+        if ignoreCase then
+            if evalTag:lower() ~= tag:lower() then
+                return false
+            end
+        else
+            if evalTag ~= tag then
+                return false
+            end
+        end
+
+        -- Evaluate numeric predicates directly
+        if tonumber(expression) then
+            return tonumber(expression)
+        end
+
+        return eval_predicate(value, expression, ignoreCase)
+    else
+        -- Match by tag name
+        if ignoreCase then
+            return (tag:lower() == tagExpr:lower())
+        else
+            return (tag == tagExpr)
+        end
+    end
+end
+
+--- Inserts a leaf node into the result table.
+-- @param self The XPath object.
+-- @param leaf The leaf node to insert.
 function XPath:_insert_leaf(leaf)
-	local option = self._option
-	if type(leaf) == "table" then
-		local value
-		if option == nil then
-			value = leaf
-		elseif option == "text()" then
-			value = leaf[1]
-		elseif option == "node()" then
-			value = leaf.tag
-		elseif option:find("@") == 1 then
-			value = leaf.attr[option:sub(2)]
-		end
-		table.insert(self._result_table, value)
-	end
+    local option = self._option
+    if type(leaf) == "table" then
+        local value
+        if option == nil then
+            value = leaf
+        elseif option == "text()" then
+            value = leaf[1]
+        elseif option == "node()" then
+            value = leaf.tag
+        elseif option:find("@") == 1 then
+            value = leaf.attr[option:sub(2)]
+        end
+        table.insert(self._result_table, value)
+    end
 end
 
+--- Parses XML nodes recursively according to the provided tags.
+-- @param self The XPath object.
+-- @param tags The tags to match.
+-- @param xmlTable The XML table to parse.
+-- @param counter The current tag index.
+-- @param recursive Whether to parse recursively.
+function XPath:parseNodes(tags, xmlTable, counter, recursive)
+    if counter > #tags then
+        return nil
+    end
+    local currentTag = tags[counter]
 
-local function match(tag,tagAttr,tagExpr,nextTag)
-	local expression,evalTag
-
-	-- check if its a wild card
-	if tagExpr == "*" then
-		return true
-	end
-
-	-- check if its empty
-	if tagExpr == "" then
-		if tag == nextTag then
-			return false,1
-		else
-			return false,0
-		end
-	end
-
-	-- check if there is an expression to evaluate
-	if tagExpr:find("[[]") ~= nil and tagExpr:find("[]]") ~= nil then
-		evalTag = tagExpr:sub(1,tagExpr:find("[[]")-1)
-		expression = tagExpr:sub(tagExpr:find("[[]")+1,tagExpr:find("[]]")-1)
-		if evalTag ~= tag then
-			return false
-		end
-	else
-		return (tag == tagExpr)
-	end
-
-	-- check if the expression is an attribute
-	if expression:find("@") ~= nil then
-		local evalAttr,evalValue
-		evalAttr = expression:sub(expression:find("[@]")+1,expression:find("[=]")-1)
-		evalValue = string.gsub(expression:sub(expression:find("[=]")+1),"'","")
-		evalValue = evalValue:gsub("\"","")
-		if tagAttr[evalAttr] ~= evalValue then
-			return false
-		else
-			return true
-		end
-	end
+    local tagMatchCount = 0
+    for idx, value in ipairs(xmlTable) do
+        if type(value) == "table" then
+            if value.tag ~= nil and value.attr ~= nil then
+                local x, y = match(value.tag, currentTag, value, self._ignoreCase)
+                if type(x) == "number" then
+                    if x == idx then
+                        self:parseNodes(tags, { value }, counter + 1)
+                    end
+                elseif x then
+                    tagMatchCount = tagMatchCount + 1
+                    if y then
+                        if tagMatchCount == y then
+                            if #tags == counter then
+                                self:_insert_leaf(value)
+                            else
+                                self:parseNodes(tags, value, counter + 1)
+                            end
+                        end
+                    else
+                        if #tags == counter then
+                            self:_insert_leaf(value)
+                        else
+                            self:parseNodes(tags, value, counter + 1)
+                        end
+                    end
+                end
+                -- Recursively parse children if starting with "//"
+                if recursive and counter == 1 then
+                    self:parseNodes(tags, value, counter, true)
+                end
+            end
+        end
+    end
 end
 
-function XPath:parseNodes(tags, xmlTable, counter)
-	if counter > #tags then
-		return nil
-	end
-	local currentTag = tags[counter]
-	local nextTag
-	if #tags > counter then
-		nextTag = tags[counter+1]
-	end
-	for _,value in ipairs(xmlTable) do
-		if type(value) == "table" then
-			if value.tag ~= nil and value.attr ~= nil then
-				local x,y = match(value.tag,value.attr,currentTag,nextTag)
-				if x then
-					if #tags == counter then
-						self:_insert_leaf(value)
-					else
-						self:parseNodes(tags,value,counter+1)
-					end
-				else
-					if y ~= nil then
-						if y == 1 then
-							if counter+1 == #tags then
-								self:_insert_leaf(value)
-							else
-								self:parseNodes(tags,value,counter+2)
-							end
-						else
-							self:parseNodes(tags,value,counter)
-						end
-					end
-				end
-			end
-		end
-	end
-end
+--- Selects nodes from the XML document based on the given XPath expression.
+-- @param xml The XML table to search.
+-- @param xpath The XPath expression.
+-- @param ignoreCase Boolean to ignore case in tag matching.
+-- @return A table containing the matched nodes.
+local function selectNodes(xml, xpath, ignoreCase)
+    assert(type(xml) == "table")
+    assert(type(xpath) == "string")
 
-local function selectNodes(xml,xpath)
-	assert(type(xml) == "table")
-	assert(type(xpath) == "string")
+    local xmlTree = { xml }
+    local option
+    local tags = _split(xpath, '[\\/]+')
 
-	local xmlTree = { xml }
-  local option
-	local tags = _split(xpath,'[\\/]+')
+    local lastTag = tags[#tags]
+    if lastTag == "text()" or lastTag == "node()" or lastTag:find("@") == 1 then
+        option = tags[#tags]
+        table.remove(tags, #tags)
+    end
 
-	local lastTag = tags[#tags]
-	if lastTag == "text()" or lastTag == "node()" or lastTag:find("@") == 1 then
-		option = tags[#tags]
-		table.remove(tags,#tags)
-	end
+    local recursive = false
+    if xpath:find("//") == 1 then
+        table.insert(tags, 1, "")
+        recursive = true
+    end
 
-	if xpath:find("//") == 1 then
-		table.insert(tags,1,"")
-	end
-
-	local ctx = XPath._new(option)
-	ctx:parseNodes(tags, xmlTree, 1)
-	return ctx._result_table
+    local ctx = XPath._new(option, ignoreCase)
+    ctx:parseNodes(tags, xmlTree, 1, recursive)
+    return ctx._result_table
 end
 
 return {
-	selectNodes = selectNodes,
+    selectNodes = selectNodes,
 }
-

--- a/t/test.t
+++ b/t/test.t
@@ -3,7 +3,6 @@
 require 'Test.More'
 local x = require "luaxpath"
 local lom = require "lxp.lom"
-local json = require "cjson"
 
 local xmlTest =
 [[
@@ -98,7 +97,6 @@ end)
 -- subtest("get all child nodes of root that contains a name of element", function()
 --     plan(1)
 --     local nodes = x.selectNodes(root, '/root[contains(name, "element")]')
---     print(json.encode(nodes))
 --     is( #nodes, 3);
 -- end)
 

--- a/t/test.t
+++ b/t/test.t
@@ -3,20 +3,23 @@
 require 'Test.More'
 local x = require "luaxpath"
 local lom = require "lxp.lom"
+local json = require "cjson"
 
 local xmlTest =
 [[
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<root>
-	<element id="1" name="element1">text of the first element</element>
-        <element id="2" name="element2">
-		<subelement>text of the second element</subelement>
-        </element>
+<root xmlns:test="https://test.test/">
+    <element id="1" name="element1">text of the first element</element>
+    <element id="2" name="element2">
+      <subelement>text of the second element</subelement>
+    </element>
+    <test:newElement id="1" name="newElement" test="testing">
+      <test>text of the test element</test>
+    </test:newElement>
 </root>
 ]]
 
 local root = lom.parse(xmlTest)
--- dump(root)
 
 subtest("get all elements", function()
     plan(2)
@@ -35,20 +38,68 @@ subtest("get the subelement text", function()
     is_deeply(text, { 'text of the second element' })
 end)
 
-
-subtest("get the first element", function()
+subtest("get the element by attribute id 1", function()
     plan(2)
     local nodes = x.selectNodes(root, '/root/element[@id="1"]')
-    is( #nodes, 1)
+    is(#nodes, 1);
+    is_deeply(nodes[1], {
+        'text of the first element',
+        attr = { "id", "name", id="1", name="element1" },
+        tag = "element",
+    });
+end)
+
+subtest("get node two by index", function()
+    plan(2)
+    local nodes = x.selectNodes(root, '/root/element[2]')
+    is( #nodes, 1);
+    is( nodes[1]['attr']['id'], "2")
+end)
+
+subtest("get the first element node, with ignoring the case of element", function()
+    plan(2)
+    local nodes = x.selectNodes(root, '/root/ELEMENT[1]',true)
+    is( #nodes, 1);
     is( nodes[1]['attr']['id'], "1")
 end)
 
--- not done yet
--- subtest("get node by index", function()
---     plan(2)
---     local nodes = x.selectNodes(root, '/root/element[1]')
---     is( #nodes, 1)
---     is( nodes[1]['attr']['id'], "1")
+subtest("get the newElement node and make use of the namespace in the tag name", function()
+    plan(2)
+    local nodes = x.selectNodes(root, '/root/test:newElement')
+    is( #nodes, 1);
+    is( nodes[1]['attr']['name'], "newElement")
+end)
+
+subtest("get the node that has a child node that contains a tag name of subelement", function()
+    plan(1)
+    local nodes = x.selectNodes(root, '//element[subelement="text of the second element"]')
+    is( #nodes, 1);
+end)
+
+subtest("get any node that has an attribute of test", function()
+    plan(1)
+    local nodes = x.selectNodes(root, '//*/@test')
+    is( #nodes, 1);
+end)
+
+subtest("get the node by name", function()
+    plan(1)
+    local nodes = x.selectNodes(root, '/root/element/node()')
+    is( #nodes, 2);
+end)
+
+subtest("get all child nodes of root", function()
+    plan(1)
+    local nodes = x.selectNodes(root, '/root/*')
+    is( #nodes, 3);
+end)
+
+-- not done
+-- subtest("get all child nodes of root that contains a name of element", function()
+--     plan(1)
+--     local nodes = x.selectNodes(root, '/root[contains(name, "element")]')
+--     print(json.encode(nodes))
+--     is( #nodes, 3);
 -- end)
 
-done_testing(3)
+done_testing(10)

--- a/t/test.t
+++ b/t/test.t
@@ -93,11 +93,16 @@ subtest("get all child nodes of root", function()
     is( #nodes, 3);
 end)
 
--- not done
--- subtest("get all child nodes of root that contains a name of element", function()
---     plan(1)
---     local nodes = x.selectNodes(root, '/root[contains(name, "element")]')
---     is( #nodes, 3);
--- end)
+subtest("get all element nodes that contains an attribute of name which is equal to element", function()
+    plan(1)
+    local nodes = x.selectNodes(root, '/root/element[contains(@name, "element")]')
+    is( #nodes, 2);
+end)
 
-done_testing(10)
+subtest("get all element nodes that contains an attribute of name which starts with ele", function()
+    plan(1)
+    local nodes = x.selectNodes(root, '/root/element[starts-with(@name, "ele")]')
+    is( #nodes, 2);
+end)
+
+done_testing(12)


### PR DESCRIPTION
I have version bumped from version 1.2.4 to 1.3.0.

Added ignore case functionality and catered for more Xpath expressions. 
Added comments throughout library.

### XPath Expressions that Work
**Absolute Path:**
XPath: /methodCall/methodName
Description: Selects the methodName element inside the methodCall element.

**Relative Path:**
XPath: //struct
Description: Selects all struct elements in the document, regardless of their position.

**Selecting Attributes:**
XPath: /methodCall/@id
Description: Selects the id attribute of the methodCall element.

**Selecting Elements by Attribute Value:**
XPath: //name[@test='msisdn_test']
Description: Selects all name elements that have an attribute test with the value msisdn_test.

**Numeric Predicate:**
XPath: //member[1]
Description: Selects the first member element.

**Multiple Numeric Predicates:**
XPath: //member[2]
Description: Selects the second member element.

**Text Node:**
XPath: /methodCall/methodName/text()
Description: Selects the text content of the methodName element.

**Node Name:**
XPath: /methodCall/node()
Description: Selects the name of the methodCall element.

**Wildcard:**
XPath: //name/*
Description: Selects all child elements of all name elements.

**Contains Function:**
XPath: //member[contains(name, 'MSISDN')]
Description: Selects all member elements whose name child contains the string MSISDN.

### XPath Expressions that Do Not Work

**Functions Other Than contains and starts-with:**
XPath: //member[count(name) > 1]
Description: This script does not support functions other than contains and starts-with.

**Axis Specifiers:**
XPath: //member/preceding-sibling::*
Description: This script does not support axis specifiers like preceding-sibling.

**Boolean Operators:**
XPath: //member[@type='A' or @type='B']
Description: This script does not support boolean operators like or and and.

**Namespace Handling:**
XPath: //ns:member
Description: This script does not support namespace handling.

**Complex Expressions:**
XPath: //member[name='MSISDN' and @type='string']
Description: This script does not support complex expressions combining multiple conditions.

### Summary
The provided script supports a subset of XPath expressions, focusing on basic element selection, attributes, and simple predicates. More advanced features like boolean operators, axis specifiers, namespace handling, and complex expressions are not supported. This makes the script suitable for simpler XML querying tasks but not for more complex XPath expressions.